### PR TITLE
Use "dot" in the path instead of depending on /usr/bin/dot

### DIFF
--- a/src/main/scala/reftree/Diagram.scala
+++ b/src/main/scala/reftree/Diagram.scala
@@ -101,7 +101,7 @@ case class Diagram(output: Path = Paths.get("diagram.png"), verticalSpacing: Dou
       Some(DotLayout.dot), Some(DotFormat.png), Some(output.toFile),
       Seq("-Gdpi=300")
     )
-    val process = Process(dotBinary.getAbsolutePath, opts.generate)
+    val process = Process("dot", opts.generate)
     val io = new ProcessIO(
       GraphInputHandler.handle(graph), Function.const(()), Function.const(()), false
     )


### PR DESCRIPTION
dotBinary.getAbsolutePath points to /usr/bin/dot. This may work in some linux distributions but is not portable. Using just "dot" will work as long as dot is in the path (OSX, Windows, etc)
