### PR TITLE
Upgrade to Fastparse2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,7 +47,7 @@ val core = crossProject.in(file("core"))
     libraryDependencies ++= Seq(
       "com.chuusai" %%% "shapeless" % "2.3.2",
       "com.lihaoyi" %%% "sourcecode" % "0.1.3",
-      "com.lihaoyi" %%% "fastparse" % "0.4.3",
+      "com.lihaoyi" %%% "fastparse" % "2.0.5",
       "io.github.stanch" %%% "zipper" % "0.5.2",
       "com.softwaremill.quicklens" %%% "quicklens" % "1.4.8",
       "com.github.julien-truffaut" %%% "monocle-macro" % "1.4.0",
@@ -86,7 +86,7 @@ val demo = crossProject.in(file("demo"))
   )
   .jvmSettings(
     libraryDependencies ++= Seq(
-      "com.lihaoyi" % "ammonite" % "0.9.9" % Test cross CrossVersion.full
+      "com.lihaoyi" % "ammonite" % "1.4.2" % Test cross CrossVersion.full
     )
   )
   .jsSettings(

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,9 @@
+// shadow sbt-scalajs' crossProject and CrossType from Scala.js 0.6.x
+import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+
 val commonSettings = Seq(
-  scalaVersion := "2.11.11",
-  crossScalaVersions := Seq("2.11.11", "2.12.2"),
+  scalaVersion := "2.11.12",
+  crossScalaVersions := Seq("2.11.12", "2.12.7"),
   scalacOptions ++= Seq(
     "-feature", "-deprecation",
     "-Xlint", "-Xfatal-warnings"
@@ -40,7 +43,8 @@ lazy val publishing = Seq(
   publishTo := Some(Opts.resolver.sonatypeStaging)
 )
 
-val core = crossProject.in(file("core"))
+val core = crossProject(JSPlatform, JVMPlatform)
+  .in(file("core"))
   .settings(commonSettings)
   .settings(
     name := "reftree",
@@ -76,7 +80,8 @@ val core = crossProject.in(file("core"))
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
 
-val demo = crossProject.in(file("demo"))
+val demo = crossProject(JSPlatform, JVMPlatform)
+  .in(file("demo"))
   .settings(commonSettings)
   .dependsOn(core)
   .settings(

--- a/demo/js/src/main/scala/reftree/demo/JsDemo.scala
+++ b/demo/js/src/main/scala/reftree/demo/JsDemo.scala
@@ -3,11 +3,10 @@ package reftree.demo
 import reftree.diagram.Animation
 import reftree.render.Renderer
 
-import scala.scalajs.js
 import org.scalajs.dom
 
-object JsDemo extends js.JSApp {
-  def main(): Unit = {
+object JsDemo {
+  def main(args: Array[String]): Unit = {
     val renderer = Renderer()
     import renderer._
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,2 @@
-sbt.version=0.13.13
+sbt.version=0.13.17
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -4,7 +4,7 @@ addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.2")
 
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.17")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.2.1")
 
@@ -15,3 +15,5 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "1.3.0")
 addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
 
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.0")
+
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")


### PR DESCRIPTION
This should fix #23.

There are a few syntax changes necessary for fastparse 2 compatibility.
It also pulls in the latest version of scala-js, which in turn requires a newer sbt version and a few changes due to deprecations.
I also upgraded Scala to the latest minor version respectively, but didn't start upgrading other libraries.