### PR TITLE
Update Fastparse dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,7 +51,7 @@ val core = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "com.chuusai" %%% "shapeless" % "2.3.2",
       "com.lihaoyi" %%% "sourcecode" % "0.1.3",
-      "com.lihaoyi" %%% "fastparse" % "2.0.5",
+      "com.lihaoyi" %%% "fastparse" % "2.1.2",
       "io.github.stanch" %%% "zipper" % "0.5.2",
       "com.softwaremill.quicklens" %%% "quicklens" % "1.4.8",
       "com.github.julien-truffaut" %%% "monocle-macro" % "1.4.0",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
-sbt.version=0.13.17
+sbt.version=0.13.18
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,7 +2,7 @@ addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.0")
 
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.5.2")
 
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M15-1")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.25")
 


### PR DESCRIPTION
Update to Fastparse 2.1.2 to be compatible with https://almond.sh/ (so we can run reftree in Jupyter notebooks).

Also requires bumping sbt and coursier.