### PR TITLE
Set name for the root module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,6 +122,7 @@ lazy val root = project.in(file("."))
   .aggregate(coreJVM, coreJS, demoJVM, demoJS)
   .settings(commonSettings)
   .settings(
+    name := "reftree-root",
     publish := {},
     publishLocal := {},
     publishArtifact := false


### PR DESCRIPTION
This tiny tweak enhances the navigation in $IDE between different projects (right now it displays as 'root' which is not informative).